### PR TITLE
Update template lint config for Octane

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.template-lintrc.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.template-lintrc.js
@@ -1,10 +1,8 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended',
+  extends: 'octane',
   rules: {
     'no-bare-strings': true,
-    'no-implicit-this': true,
-    'no-inline-styles': false,
   },
 };


### PR DESCRIPTION
`no-implicit-this` is already included, don't know why `no-inline-styles` was disabled by default, but would not agree with this. https://github.com/jelhan/ember-style-modifier can be used instead.