### PR TITLE
Add better default targets

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/config/targets.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/config/targets.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'last 2 Safari versions'];
+
+module.exports = {
+  browsers,
+};


### PR DESCRIPTION
Exclude IE by default, as we usually don't need support for it.