### PR TITLE
Fix adding not-found route

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/index.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const EmberRouterGenerator = require('ember-router-generator');
 
 module.exports = {
   description: 'A boilerplate for Ember apps, tailored for use in kaliber5',
@@ -133,11 +134,12 @@ module.exports = {
   },
 
   async _modifyRouter() {
-    const route = "  this.route('not-found', { path: '/*wildcard' });";
+    const routerPath = 'app/router.js';
+    const source = fs.readFileSync(routerPath, 'utf-8');
+    const routes = new EmberRouterGenerator(source);
+    const newRoutes = routes.add('not-found', { path: '/*wildcard' });
 
-    await this.insertIntoFile('app/router.js', route, {
-      after: 'Router.map(function () {\n',
-    });
+    fs.writeFileSync(routerPath, newRoutes.code());
 
     this.ui.writeLine('Added not-found route to app/router.js');
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:ember-compatibility": "ember try:each",
     "blueprint:fix": "prettier --config 'blueprints/@kaliber5/k5-ember-boilerplate/files/.prettierrc.yml' --write 'blueprints/**/*.(js|ts)'"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ember-router-generator": "^2.0.0"
+  },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",


### PR DESCRIPTION
The previous implementation used a simple find-and-replace like solution, which was easy to break when the default file contents changed a bit. This was the case now, as the default blueprint writes the call in a single line, which did not match anymore:

```
Router.map(function () {});
```

Now this uses the standard AST-based ember library for router generation.