### PR TITLE
Add default loading indicator

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,8 @@
-'use strict';
+"use strict";
 
 module.exports = {
-  extends: 'octane'
+  extends: 'octane',
+  rules: {
+    'no-curly-component-invocation': { allow: ["while-loading"] },
+  },
 };

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.template-lintrc.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.template-lintrc.js
@@ -4,5 +4,6 @@ module.exports = {
   extends: 'octane',
   rules: {
     'no-bare-strings': true,
+    'no-curly-component-invocation': { allow: ['while-loading'] },
   },
 };

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/components/loading/overlay.hbs
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/components/loading/overlay.hbs
@@ -1,0 +1,4 @@
+{{!-- this uses the loading classes globally defined in index.html, to make sure the pre-loader matches the in-app loader --}}
+<div class="loading-overlay">
+  <Loading::Spinner />
+</div>

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/components/loading/spinner.hbs
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/components/loading/spinner.hbs
@@ -1,0 +1,8 @@
+{{!-- this uses the loading classes globally defined by Bootstrap --}}
+<div
+  class="spinner-border text-primary"
+  role="status"
+  ...attributes
+>
+  <span class="sr-only">{{t "loading"}}</span>
+</div>

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/index.html
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/index.html
@@ -20,6 +20,18 @@
   <body>
     {{content-for "body"}}
 
+    <div class="loading-overlay" id="app-loading">
+      <div class="spinner-border text-primary" role="status"><span class="sr-only">Lade...</span></div>
+    </div>
+    <style>
+      .loading-overlay {
+        position: fixed;
+        left: 50vw;
+        top: 50vh;
+        transform: translate(-50%,-50%);
+      }
+    </style>
+
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/<%= dasherizedPackageName %>.js"></script>
 

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/pods/application/template.hbs
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/__root__/pods/application/template.hbs
@@ -1,3 +1,7 @@
 {{outlet}}
 
 <FlashMessages/>
+
+{{#while-loading}}
+  <Loading::Overlay/>
+{{/while-loading}}

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/translations/de-de.yaml
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/translations/de-de.yaml
@@ -1,6 +1,7 @@
 index:
   title: Willkommen
 
+loading: Lade...
 errors:
   somethingWentWrong: Etwas ist schiefgelaufen!
   backToHomepage: zurück zur Startseite

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/translations/en-us.yaml
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/translations/en-us.yaml
@@ -1,6 +1,7 @@
 index:
   title: Welcome
 
+loading: Loading...
 errors:
   somethingWentWrong: Something went wrong!
   backToHomepage: Back to homepage

--- a/blueprints/@kaliber5/k5-ember-boilerplate/index.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/index.js
@@ -42,6 +42,7 @@ module.exports = {
         { name: 'ember-css-modules', target: '~1.3.0-beta.1' },
         { name: 'ember-css-modules-sass' },
         { name: 'ember-intl' },
+        { name: 'ember-loading' },
         { name: 'ember-math-helpers' },
         { name: 'ember-svg-jar' },
         { name: 'ember-truth-helpers' },


### PR DESCRIPTION
Adds a Bootstrap-based spinner as a default loading indicator, as a pre-loader in index.html and the same as an in-app component (when routes are loading).