### PR TITLE
Fix lint-staged config

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.lintstagedrc.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.lintstagedrc.js
@@ -6,7 +6,7 @@ module.exports = {
   // and TSC does not support providing a config and a path to a specific file at the same time.
   // Thus, two separate configs are used: one for Node, one for browser.
   // The function allows running the command globally, rather than once per each staged file.
-  '**/*.ts': 'yarn lint:ts',
+  '**/*.ts': () => 'yarn lint:ts',
 
   // Run ESLint, typescript-eslint and Prettier on staged files only
   '**/*.{js,ts}': 'yarn lint:eslint --fix',


### PR DESCRIPTION
Tested on kaliber5-website, this should be finally the version that works correctly, running `yarn lint:ts` on *all*  project files instead of just the staged ones (as it was previously).