### PR TITLE
Fix CI config

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.github/workflows/ci.yml
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: 12
 
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 


### PR DESCRIPTION
Installing private packagles like our `@kaliber5/ember-k5-boilerplate` adodn itself does not work out of the box in Github Actions, we need to add a personal token for the Github Package Registry access. Backported from `kaliber5-website`