### PR TITLE
Fix deployment config

### DIFF
--- a/blueprints/k5-deployment-aws/files/.github/workflows/deploy.yml
+++ b/blueprints/k5-deployment-aws/files/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 12
 
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
@@ -74,6 +77,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -132,6 +138,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/blueprints/k5-deployment-ssh/files/.github/workflows/deploy.yml
+++ b/blueprints/k5-deployment-ssh/files/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 12
 
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
@@ -47,6 +50,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -83,6 +89,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: Add Github Package Registry Auth Token
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}" > ~/.npmrc
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Installing private packagles like our `@kaliber5/ember-k5-boilerplate` adodn itself does not work out of the box in Github Actions, we need to add a personal token for the Github Package Registry access. Backported from `kaliber5-website`