### PR TITLE
Align package.json scripts to latest Ember CLI defaults

### DIFF
--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.eslintignore
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.eslintignore
@@ -13,6 +13,7 @@
 # misc
 /coverage/
 !.*
+.eslintcache
 
 # ember-try
 /.node_modules.ember-try/

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.gitignore
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.gitignore
@@ -12,6 +12,7 @@
 # /.env*
 /.pnp*
 /.sass-cache/
+/.eslintcache
 /*.lock
 /coverage/
 /*.log*

--- a/blueprints/@kaliber5/k5-ember-boilerplate/files/.lintstagedrc.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/files/.lintstagedrc.js
@@ -9,8 +9,8 @@ module.exports = {
   '**/*.ts': () => 'yarn lint:ts',
 
   // Run ESLint, typescript-eslint and Prettier on staged files only
-  '**/*.{js,ts}': 'yarn lint:eslint --fix',
+  '**/*.{js,ts}': 'yarn lint:js:fix',
 
   // Template lint
-  '**/*.hbs': 'yarn ember-template-lint',
+  '**/*.hbs': 'yarn lint:hbs:fix',
 };

--- a/blueprints/@kaliber5/k5-ember-boilerplate/index.js
+++ b/blueprints/@kaliber5/k5-ember-boilerplate/index.js
@@ -117,16 +117,13 @@ module.exports = {
       yarn: '1.22.4',
     };
 
-    pkg.scripts['lint:hbs'] = 'ember-template-lint .';
     pkg.scripts['lint:ts'] = 'tsc --noEmit';
-    pkg.scripts['lint:eslint'] = 'eslint . --ext .js,.ts';
-    pkg.scripts['lint:js'] = 'yarn lint:ts && yarn lint:eslint';
-    pkg.scripts['lint'] = 'yarn lint:js && yarn lint:hbs';
     pkg.scripts['lint-staged'] = 'lint-staged';
-    pkg.scripts['start'] = 'ember serve';
-    pkg.scripts['test'] = 'ember test';
-    pkg.scripts['dev-prod'] = 'cross-env DOTENV=dev-self ember s --proxy http://api.blutimes-prod.kaliber5.de';
-    pkg.scripts['dev-staging'] = 'cross-env DOTENV=dev-self ember s --proxy http://api.blutimes-staging.kaliber5.d';
+
+    // re-enable when we have a way to set the correct API URLs here
+    // see https://github.com/kaliber5/k5-ember-boilerplate/issues/120
+    // pkg.scripts['dev-prod'] = 'cross-env DOTENV=dev-self ember s --proxy http://api.blutimes-prod.kaliber5.de';
+    // pkg.scripts['dev-staging'] = 'cross-env DOTENV=dev-self ember s --proxy http://api.blutimes-staging.kaliber5.d';
 
     pkg.husky = {
       hooks: {


### PR DESCRIPTION
Otherwise this would cause conflicts, e.g. with ember-cli-update.

* `yarn lint`/`yarn test` run all `lint:*`/`test:*` scripts now, so we don't need the previous `lint:js`
* `lint:js` now runs ESLint.
* ESLint does not require `--ext .js/.ts` anymore, when `*.ts` files have an override in `.eslintrc.js`

See https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/package.json